### PR TITLE
Added example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ webshot('google.com', 'google.png', function(err) {
   // screenshot now saved to google.png 
 });
 ```
-Alternately, if phantomJS is not installed in the path:
+Alternately, if phantomJS is not already installed:
+```
+npm install phantomjs --save
+```
 
 ```javascript
 var webshot = require('webshot');


### PR DESCRIPTION
If a user doesn't have phantomJS installed globally, it might be helpful to explain that they can use the phantomJS binary in the node_modules folder.
