### PR TITLE
Added a timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ An optional `options` object can be passed as the third parameter in a call to w
       <td>Number of milliseconds to wait after a page loads before taking the screenshot.
       </td> 
     </tr>
+    <tr>
+      <th>timeout</th>
+      <td>0</td>
+      <td>Number of milliseconds to wait before killing the phantomjs process and assuming webshotting has failed.
+      (0 is no timeout.)
+      </td>
+    </tr>
   </tbody>
 </table>
 

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -20,6 +20,7 @@ var defaults = {
 , userAgent: ''
 , streamType: 'png'
 , renderDelay: 0
+, timeout: 0
 };
 
 module.exports = function() {
@@ -65,7 +66,7 @@ module.exports = function() {
     : options.streamType;
 
   if (!~extensions.indexOf(extension.toLowerCase())) {
-    cb(new Error('All files must end with one of the following extensions: ' 
+    return cb(new Error('All files must end with one of the following extensions: '
       + extensions.join(', ')));
   }
 
@@ -118,10 +119,41 @@ function spawnPhantom(site, path, options, cb) {
   var phantomProc = childProcess.spawn(options.phantomPath, phantomArgs);
 
   if (path) {
+
+    // This variable will contain our timeout ID.
+    var timeoutID = null;
+
+    // Whether or not we've called our callback already.
+    var calledCallback = false;
+
+    // Only set the timer if the timeout has been specified (by default it's not).
+    if (options.timeout) {
+      timeoutID = setTimeout(function() {
+        // The phantomjs process didn't exit in time.
+        // Double-check we didn't already call the callback already as that would happen
+        // when the process has already exited. Sending a SIGKILL to a PID that might
+        // be handed out to another process could be potentially very dangerous.
+        if (!calledCallback) {
+          calledCallback = true;
+
+          // Send the kill signal
+          phantomProc.kill('SIGKILL');
+
+          // Call our callback.
+          cb(new Error('PhantomJS did not respond within the given timeout setting.'));
+        }
+      }, options.timeout);
+    }
     phantomProc.on('exit', function(code) {
-      cb(code
-        ? new Error('PhantomJS exited with return value ' + code)
-        : null);
+      if (!calledCallback) {
+        calledCallback = true;
+
+        // No need to run the timeout anymore.
+        clearTimeout(timeoutID);
+        cb(code
+          ? new Error('PhantomJS exited with return value ' + code)
+          : null);
+      }
     });
   } else {
 

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -29,7 +29,6 @@ if (args.userAgent) {
 }
 
 page.open(args.site, function(status) {
-
   if (status === 'fail') {
     page.close();
     phantom.exit(1);
@@ -41,20 +40,22 @@ page.open(args.site, function(status) {
 
     // Determine the page's dimensions
     var pageDimensions = page.evaluate(function() {
+      var body = document.body || {};
+      var documentElement = document.documentElement || {};
       return {
         width: Math.max( 
-          document.body.offsetWidth
-        , document.body.scrollWidth
-        , document.documentElement.clientWidth
-        , document.documentElement.scrollWidth
-        , document.documentElement.offsetWidth
+          body.offsetWidth
+        , body.scrollWidth
+        , documentElement.clientWidth
+        , documentElement.scrollWidth
+        , documentElement.offsetWidth
         )
       , height: Math.max(
-          document.body.offsetHeight
-        , document.body.scrollHeight
-        , document.documentElement.clientHeight
-        , document.documentElement.scrollHeight
-        , document.documentElement.offsetHeight
+          body.offsetHeight
+        , body.scrollHeight
+        , documentElement.clientHeight
+        , documentElement.scrollHeight
+        , documentElement.offsetHeight
         )
       };
     });

--- a/test/tests.js
+++ b/test/tests.js
@@ -167,6 +167,7 @@ describe('Handling screenshot dimension options', function() {
 describe('Passing errors for bad input', function() {
   
   it('Passes an error if an invalid extension is given', function(done) {
+    this.timeout(20000);
 
     webshot('betabeat.com', 'output.xyz', function(err) {
       should.exist(err);
@@ -175,6 +176,7 @@ describe('Passing errors for bad input', function() {
   });
 
   it('Passes an error if a misformatted address is given', function(done) { 
+    this.timeout(20000);
 
     webshot('abcdefghijklmnop', 'google.png', function(err) {
       should.exist(err);
@@ -183,9 +185,29 @@ describe('Passing errors for bad input', function() {
   });
 
   it('Passes an error if no webpage exists at the address', function(done) { 
+    this.timeout(20000);
 
     webshot('http://abc1234xyz123455555.com', testFile, function(err) {
       should.exist(err);
+      done();
+    });
+  });
+});
+
+describe('Time out', function() {
+  it('should time out', function(done) {
+    this.timeout(20000);
+
+    // If the render delay is larger than the timeout delay, the timeout should be triggered.
+    var options = {
+      renderDelay: 10000,
+      timeout: 3000
+    };
+
+    var url = 'file://' + __dirname + '/fixtures/1.html';
+    webshot(url, testFile, options, function(err) {
+      should.exist(err);
+      should.equal(err.message, 'PhantomJS did not respond within the given timeout setting.');
       done();
     });
   });


### PR DESCRIPTION
We noticed that the PhantomJS process was sometime inexplicably hanging.
This PR adds a timeout option (as long as you're using the path option).

I also added the following:
Immediately returning when the extension of the file is not supported.
Little more robust PhantomJS script.
