### PR TITLE
Making phantomjs optional

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -1,7 +1,6 @@
 var url = require('url')
   , fs = require('fs')
   , stream = require('stream')
-  , phantomjs = require('phantomjs')
   , childProcess = require('child_process')
   , phantomScript = __dirname + '/webshot.phantom.js'
   , extensions = ['jpeg', 'jpg', 'png', 'pdf'];
@@ -17,12 +16,14 @@ var defaults = {
   , height: 'window'
   }
 , script: function() {}
-, phantomPath: phantomjs.path
 , userAgent: ''
 , streamType: 'png'
 , renderDelay: 0
 , timeout: 0
 };
+
+// Apply the compiled phantomjs path only if it compiled successfully
+try { defaults.phantomPath = require('phantomjs').path } catch (ex) {}
 
 module.exports = function() {
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "http://github.com/brenden/node-webshot.git"
   },
   "engine": [ "node >=0.7.00" ],
-  "dependencies": {
+  "optionalDependencies": {
     "phantomjs": "~1.9.0-1"
   },
   "devDependencies": {


### PR DESCRIPTION
It would be great if the NPM build of phantomjs could be optional in favour of an external package. In a case where the npm build of phantomjs fails, but you have a version of phantomjs installed that works (e.g., rpm or deb), webshot can fall back to the external version of phantomjs as it does still take in a custom phantomjs path.
