### PR TITLE
page.close() throws an exception with phantomjs 1.6.0.

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -111,7 +111,6 @@ page.open(args.site, function(status) {
       console.log(page.renderBase64(args.streamType));
     }
 
-    page.close();
     phantom.exit(0);
   }
   


### PR DESCRIPTION
Hi,
Not sure if this might be an environmental issue at my end, but on Ubuntu 12.10 with phantomjs 1.6.0 webshot.phantom.js generates the following exception:

> TypeError: 'undefined' is not a function (evaluating 'page.close()')

I've removed the call to page.close().
