### PR TITLE
Option to set page.paperSize for PDF capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ An optional `options` object can be passed as the third parameter in a call to w
       </td> 
     </tr>
     <tr>
+      <th>paperSize</th> 
+      <td>undefined</td>
+      <td>When generating a PDF, sets page.paperSize. Some options are documented here: https://github.com/ariya/phantomjs/pull/15 Example: <code>{format: 'A4', orientation: 'portrait'}</code> 
+      </td> 
+    </tr>
+
+    <tr>
       <th>streamType</th> 
       <td>'png'</td>
       <td>If streaming is used, this designates the file format of the streamed rendering. Possible values are 

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -16,6 +16,7 @@ var defaults = {
   , height: 'window'
   }
 , script: function() {}
+, paperSize: ''
 , userAgent: ''
 , streamType: 'png'
 , phantomPath: 'phantomjs'
@@ -74,6 +75,10 @@ module.exports = function() {
       + extensions.join(', ')));
   }
 
+  if (extension.toLowerCase() == 'pdf' && options.paperSize) {
+      options.paperSize = JSON.stringify(options.paperSize);
+  }
+
   // Remove the given file if it already exists, then call phantom
   var spawn = spawnPhantom.bind(null, site, path, options, cb);
 
@@ -114,6 +119,7 @@ function spawnPhantom(site, path, options, cb) {
   , options.shotSize.height
   , options.userAgent
   , options.script
+  , options.paperSize
   , options.streamType
   , options.renderDelay
   , options.takeShotOnCallback

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -11,6 +11,7 @@ var args = {};
 , 'shotHeight'
 , 'userAgent'
 , 'script'
+, 'paperSize'
 , 'streamType'
 , 'renderDelay'
 , 'takeShotOnCallback'
@@ -27,6 +28,9 @@ page.viewportSize = {
 // Set the user agent string
 if (args.userAgent) {
   page.settings.userAgent = args.userAgent;
+}
+if (args.paperSize) {
+  page.paperSize = JSON.parse(args.paperSize);
 }
 
 page.open(args.site, function(status) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -2,7 +2,8 @@ var webshot = require('../lib/webshot')
   , should = require('should')
   , fs = require('fs')
   , im = require('imagemagick')
-  , testFile = __dirname + '/test.png';
+  , testFile = __dirname + '/test.png'
+  , testPDF = __dirname + '/test.pdf';
 
 describe('Creating screenshot images', function() {
   it('creates a screenshot', function(done) {
@@ -83,6 +84,27 @@ describe('Handling screenshot dimension options', function() {
       im.identify(testFile, function(err, features) {
         features.width.should.equal(options.windowSize.width);
         features.height.should.equal(options.windowSize.height);
+        done();
+      });
+    });
+  });
+
+  it('creates a properly-sized page for pdf shots', function(done) {
+    this.timeout(20000);
+
+    var options = {
+      paperSize: {
+        format: 'Letter'
+      , orientation: 'portrait'
+      }
+    };
+
+    webshot('flickr.com', testPDF, options, function(err) {
+      if (err) return done(err);
+
+      im.identify(testPDF, function(err, features) {
+        console.log(features);
+        features['print size'].should.equal('8.5x11');
         done();
       });
     });


### PR DESCRIPTION
When generating a PDF, need to be able to set generated paper size.

I can't find where this is documented for PhantomJS, but the implementation is here https://github.com/ariya/phantomjs/pull/15 and it's used in rasterize.js https://github.com/ariya/phantomjs/blob/master/examples/rasterize.js#L15
