### PR TITLE
Support passing command line options to phantomjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ An optional `options` object can be passed as the third parameter in a call to w
       module, and falls back to 'phantomjs' if the module isn't available.</td> 
     </tr>
     <tr>
+      <th>phantomConfig</th> 
+      <td>{}</td>
+      <td>Object with key value pairs corresponding to phantomjs <a href="https://github.com/ariya/phantomjs/wiki/API-Reference#command-line-options">command line options</a>.</td> 
+    </tr>
+    <tr>
       <th>userAgent</th> 
       <td>undefined</td>
       <td>The <code>user-agent</code> string Phantom sends to the requested page. If left unset, the default

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -137,6 +137,12 @@ function spawnPhantom(site, path, options, cb) {
     return arg.toString();
   });
 
+  if (options.phantomConfig) {
+    phantomArgs = Object.keys(options.phantomConfig).map(function (key) {
+      return '--' + key + '=' + options.phantomConfig[key];
+    }).concat(phantomArgs);
+  }
+
   var phantomProc = childProcess.spawn(options.phantomPath, phantomArgs);
 
   // This variable will contain our timeout ID.


### PR DESCRIPTION
My use case was I wanted to enable the disk cache. So my webshot option look like:

``` javascript
{phantomConfig: {"disk-cache": true}}
```

I wanted to pass a path to a JSON file (as phantom says it supports this via the --config param) but phantom did not read or set configuration options when I did this.

In the future when phantomjs has fixed the bug, webshot can support this by passing a string as the phantomConfig option but until then this'll have to do.
