### PR TITLE
Enabled support for default white background as a configuration paramete...

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,12 +133,17 @@ An optional `options` object can be passed as the parameter directly preceding t
       </td>
     </tr>
     <tr>
+      <th>defaultWhiteBackground</th>
+      <td>false</td>
+      <td>When taking the screenshot, adds a white background if not defined elsewhere.
+      </td>
+    </tr>
+    <tr>
       <th>paperSize</th>
       <td>undefined</td>
       <td>When generating a PDF, sets page.paperSize. Some options are documented here: https://github.com/ariya/phantomjs/pull/15 Example: <code>{format: 'A4', orientation: 'portrait'}</code>
       </td>
     </tr>
-
     <tr>
       <th>streamType</th>
       <td>'png'</td>

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -32,6 +32,7 @@ var defaults = {
 , timeout: 0
 , takeShotOnCallback: false
 , cookies: []
+, defaultWhiteBackground: false
 };
 
 // Apply the compiled phantomjs path only if it compiled successfully
@@ -180,6 +181,7 @@ function spawnPhantom(site, path, streaming, options, cb) {
   , options.renderDelay
   , options.takeShotOnCallback
   , options.cookies
+  , options.defaultWhiteBackground
   ].map(function(arg) {
     return arg === '' ? 'default' : arg.toString();
   });

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -109,6 +109,19 @@ var whenLoadFinished = function(status) {
     , height: pixelCount('height', args.shotHeight) - args.offsetBottom
     };
 
+    // Default to white background if required
+    if (args.defaultWhiteBackground == 'true') {
+      // added as the first element
+      // further style cascading would eventually override it
+      page.evaluate(function() {
+        var style = document.createElement('style'),
+            text  = document.createTextNode('body { background: #fff }');
+        style.setAttribute('type', 'text/css');
+        style.appendChild(text);
+        document.head.insertBefore(style, document.head.firstChild);
+      });
+    }
+
     if(args.takeShotOnCallback == 'true') {
 
       page.onCallback = function(data) {


### PR DESCRIPTION
I'm using webshot to manage on the spot and queued screen capture jobs of user provided websites.
Playing with some big bulk capture I've realized (late) some of the websites were relaying on browser defaults for background, which PhantomJS and the jpeg output didn't like much (default to black). 
I've quickly integrated the option in your library, you may want to consider the support of it since I've realized I wasn't the only one bumping in this exception.
Style element is injected before anything else, so that any CSS provided indication will override the default to white and it can be easily extended to support a user provided fallback background color instead a boolean for the white one...
Cheers
