### PR TITLE
Update webshot.phantom.js

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -5,9 +5,9 @@ var system = require('system')
 
 // Read in arguments
 var site = system.args[1];
-var path = system.args[2];
-var streaming = (system.args[3] === 'true');
-var options = JSON.parse(system.args[4]);
+var path = system.args.length == 4 ? null : system.args[2];
+var streaming = ((system.args.length == 4 ? system.args[2] : system.args[3]) === 'true');
+var options = JSON.parse(system.args.length == 4 ? system.args[3] : system.args[4]);
 
 page.viewportSize = {
   width: options.windowSize.width


### PR DESCRIPTION
Strange behavior. I use streaming and got error "SyntaxError: Unable to parse JSON string", because path in system.args[2] is empty and length system.args is equally 4(variables in the array are shifted by 1).
I use node 0.10.22 on Window 8.1.
