### PR TITLE
Options tests weren't testing options

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -361,7 +361,7 @@ describe('Handling miscellaneous options', function() {
 
     this.timeout(20000);
 
-    webshot('google.com', testPNG, function(err) {
+    webshot('google.com', testPNG, options, function(err) {
       if (err) return done(err);
 
       fs.exists(testPNG, function(exists) {
@@ -378,7 +378,7 @@ describe('Handling miscellaneous options', function() {
 
     this.timeout(20000);
 
-    webshot('google.com', testPNG, function(err) {
+    webshot('google.com', testPNG, options, function(err) {
       if (err) return done(err);
 
       fs.exists(testPNG, function(exists) {


### PR DESCRIPTION
Hey, I was digging through your tests while trying to see how cookie objects were being formatted, and happened to see that the tests in the "Handling miscellaneous options" block weren't actually being passed the options object.

Here's a PR with the fix, and I'm happy to report that the misc. options tests do in fact pass.
