### PR TITLE
added option to set onInitialized callback

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -16,6 +16,7 @@ exports.phantom = {
   }
 , defaultWhiteBackground: false
 , script: function() {}
+, onInitialized: function() {}
 , takeShotOnCallback: false
 , streamType: 'png'
 , siteType: 'url'

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -126,6 +126,9 @@ function processOptions(options, defaults) {
   // Convert 'script' function to string for later JSON serialization
   withDefaults.script = withDefaults.script.toString();
 
+  // Convert 'onInitialized' function to string for later JSON serialization
+  withDefaults.onInitialized = withDefaults.onInitialized.toString();
+
   return withDefaults;
 }
 

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -14,6 +14,8 @@ page.viewportSize = {
 , height: options.windowSize.height
 };
 
+page.onInitialized = eval('(' + options.onInitialized + ')');
+
 // Set the phantom page properties
 var toOverwrite = optUtils.mergeObjects(
   optUtils.filterObject(options, optUtils.phantomPage)


### PR DESCRIPTION
It should be possible to set the `onInitialized` callback.
In contrast to `script` this allows to run code _before_ the scripts included in the webpage.
