### PR TITLE
Add jpeg quality settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ the callback in a call to webshot.
       elsewhere.</td>
     </tr>
     <tr>
+      <th>quality</th>
+      <td>75</td>
+      <td>JPEG compression quality. A higher number will look better, but creates
+        a larger file. Quality setting has no effect when streaming.</td>
+    </tr>
+    <tr>
       <th>streamType</th>
       <td>'png'</td>
       <td>If streaming is used, this designates the file format of the streamed

--- a/lib/options.js
+++ b/lib/options.js
@@ -21,6 +21,7 @@ exports.phantom = {
 , streamType: 'png'
 , siteType: 'url'
 , renderDelay: 0
+, quality: 75
 };
 
 // Options that are just passed to the phantom page object

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -78,7 +78,7 @@ var whenLoadFinished = function(status) {
   // Render, clean up, and exit
   function renderCleanUpExit() {
     if (!streaming) {
-      page.render(path);
+      page.render(path, {quality: options.quality});
     } else {
       console.log(page.renderBase64(options.streamType));
     }


### PR DESCRIPTION
This makes it possible to control the jpeg compression quality when creating a screenshot. It will not work if you're using streaming because it's not possible to set the quality when using .renderBase64().

Default compression quality is set to 75, which is what phantomjs already uses by default.
