### PR TITLE
Incorrect this reference in stream mode

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -235,7 +235,7 @@ function spawnPhantom(site, path, streaming, options, cb) {
     phantomProc.stderr.on('data', function(data) {
       clearTimeout(timeoutID);
       cb(new Error(data));
-      this.kill();
+      phantomProc.kill();
     });
 
     phantomProc.on('exit', function() {


### PR DESCRIPTION
Hi, I have an error and believe that "this" reference is incorrect in stream mode this.kill(); Having the following error when webshot is failing in stream mode due to PhantomJS crash:

<pre>TypeError: Object #<Socket> has no method 'kill'</pre>

<pre>
phantomProc.stderr.on('data', function(data) {
      clearTimeout(timeoutID);
      cb(new Error(data));
      this.kill();
    });
</pre>
