### PR TITLE
Handled customCSS before clipRect

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -72,6 +72,17 @@ var _takeScreenshot = function(status) {
   // Wait `options.renderDelay` seconds for the page's JS to kick in
   window.setTimeout(function () {
 
+    // Handle customCSS option
+    if (options.customCSS) {
+      page.evaluate(function(customCSS) {
+        var style = document.createElement('style');
+        var text  = document.createTextNode(customCSS);
+        style.setAttribute('type', 'text/css');
+        style.appendChild(text);
+        document.head.insertBefore(style, document.head.firstChild);
+      }, options.customCSS);
+    }
+
     // Set the rectangle of the page to render
     page.clipRect = {
       top: options.shotOffset.top
@@ -91,17 +102,6 @@ var _takeScreenshot = function(status) {
         style.appendChild(text);
         document.head.insertBefore(style, document.head.firstChild);
       });
-    }
-
-    // Handle customCSS option
-    if (options.customCSS) {
-      page.evaluate(function(customCSS) {
-        var style = document.createElement('style');
-        var text  = document.createTextNode(customCSS);
-        style.setAttribute('type', 'text/css');
-        style.appendChild(text);
-        document.head.insertBefore(style, document.head.firstChild);
-      }, options.customCSS);
     }
 
     // Render, clean up, and exit


### PR DESCRIPTION
If the custom CSS altered the height of the page, the image was still at the original height; potentially cutting off the bottom of the page if shotSize.height == 'all'.