### PR TITLE
Add graceful-fs as drop in replacement for fs module

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -1,5 +1,5 @@
 var url = require('url')
-  , fs = require('fs')
+  , fs = require('graceful-fs')
   , tmp = require('tmp')
   , stream = require('stream')
   , childProcess = require('child_process')

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -1,6 +1,6 @@
 var system = require('system')
   , page = require('webpage').create()
-  , fs = require('fs')
+  , fs = require('graceful-fs')
   , optUtils = require('./options');
 
 // Read in arguments

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node >=0.7.00"
   ],
   "dependencies": {
-    "tmp": "~0.0.23"
+    "tmp": "~0.0.23",
+    "graceful-fs": "~3.0.4"
   },
   "optionalDependencies": {
     "phantomjs": "~1.9.7-1"


### PR DESCRIPTION
This will prevent `EMFILE` exceptions from being thrown if the number of open file descriptors is greater than the allowed environment limit.