### PR TITLE
Replace child_process with cross-spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 node_modules
+.ds_store

--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -2,7 +2,7 @@ var url = require('url')
   , fs = require('fs')
   , tmp = require('tmp')
   , stream = require('stream')
-  , childProcess = require('child_process')
+  , crossSpawn = require('cross-spawn')
   , optUtils = require('./options')
   , phantomScript = __dirname + '/webshot.phantom.js'
   , extensions = ['jpeg', 'jpg', 'png', 'pdf']
@@ -179,7 +179,7 @@ function spawnPhantom(site, path, streaming, options, cb) {
     }).concat(phantomArgs);
   }
 
-  var phantomProc = childProcess.spawn(options.phantomPath, phantomArgs);
+  var phantomProc = crossSpawn.spawn(options.phantomPath, phantomArgs);
 
   // This variable will contain our timeout ID.
   var timeoutID = null;

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
     "node >=0.7.00"
   ],
   "dependencies": {
+    "cross-spawn": "^0.2.3",
     "tmp": "~0.0.23"
   },
   "optionalDependencies": {
     "phantomjs": "~1.9.7-1"
   },
   "devDependencies": {
+    "imagemagick": "git://github.com/rsms/node-imagemagick.git",
     "mocha": "*",
-    "should": "*",
-    "imagemagick": "git://github.com/rsms/node-imagemagick.git"
+    "should": "*"
   },
   "main": "./lib/webshot.js",
   "scripts": {


### PR DESCRIPTION
This means that the library now works on Windows and Mac (haven't tested on Unix) more reliably.
Also Updated the .gitignore file so that I don't commit .ds_store files.

I have run the tests and there is no difference to the output between child_process and cross-spawn so everything should be fine.

Thanks,
James