### PR TITLE
Support for retina screenshots

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -179,7 +179,7 @@ if (options.siteType == 'url') {
 function pixelCount(page, dimension, value) {
 
   // Determine the page's dimensions
-  var pageDimensions = page.evaluate(function() {
+  var pageDimensions = page.evaluate(function(zoomFactor) {
     var body = document.body || {};
     var documentElement = document.documentElement || {};
     return {
@@ -189,16 +189,16 @@ function pixelCount(page, dimension, value) {
       , documentElement.clientWidth
       , documentElement.scrollWidth
       , documentElement.offsetWidth
-      )
+      ) * zoomFactor
     , height: Math.max(
         body.offsetHeight
       , body.scrollHeight
       , documentElement.clientHeight
       , documentElement.scrollHeight
       , documentElement.offsetHeight
-      )
+      ) * zoomFactor
     };
-  });
+  }, options.zoomFactor || 1);
 
   var x = {
     window: page.viewportSize[dimension]

--- a/test/tests.js
+++ b/test/tests.js
@@ -202,7 +202,7 @@ describe('Handling screenshot dimension options', function() {
 
       im.identify(testPNG, function(err, features) {
         features.width.should.equal(fixture.width);
-        features.height.should.equal(fixture.height);
+        features.height.should.equal(fixture.height * 2);
         done();
       });
     });


### PR DESCRIPTION
Using `options.zoomFactor` is helpful for creating retina-quality screenshots. 

Unfortunately, using `zoomFactor:2` with `shotSize: { width: 'all', height: 'all' }` currently results in a image cropped at 50%. 

This PR fixes this issue.