### PR TITLE
Emit error from PhantomJS script to stream

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -256,6 +256,7 @@ function spawnPhantom(site, path, streaming, options, cb) {
 
     phantomProc.stderr.on('data', function(data) {
       clearTimeout(timeoutID);
+      s.emit('error', data);
       phantomProc.kill();
     });
 

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -21,7 +21,18 @@ page.viewportSize = {
 };
 
 // Capture JS errors and ignore them
-page.onError = function(msg, trace) {};
+page.onError = function(msg, trace) {
+  var msgStack = ['ERROR: ' + msg];
+
+  if (trace && trace.length) {
+    msgStack.push('TRACE:');
+    trace.forEach(function(t) {
+      msgStack.push(' -> ' + t.file + ': ' + t.line + (t.function ? ' (in function "' + t.function +'")' : ''));
+    });
+  }
+
+  failToStderr(msgStack.join('\n'));
+};
 
 if (options.errorIfStatusIsNot200) {
   page.onResourceReceived = function(response) {


### PR DESCRIPTION
There is only one error that gets written in webshot.phantom.js at the moment, but there is no way for client code to handle or see that error.  With this PR, that error would get emitted to the stream so that client code can handle it appropriately.