### PR TITLE
Allow to override the options during the takeShot callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.swp
 node_modules
 .ds_store
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -248,6 +248,23 @@ var options = {
 };
 ```
 
+### Override options in takeShotOnCallback
+When using the takeShotOnCallback option, the page can override the options by
+providing an object instead of the string as follows:
+
+```javascript
+window.callPhantom({
+    event: 'takeShot',
+    options: {
+        shotSize: {
+            width: document.getElementsByTagName('html')[0].offsetWidth,
+            height: document.getElementsByTagName('html')[0].offsetHeight
+        }
+    }
+});
+```
+In this example the shot size will be set to the real size of the document.
+
 ## Tests
 Tests are written with [Mocha](http://visionmedia.github.com/mocha/) and can be
 run with `npm test`. The tests use [node-imagemagick](http://github.com/rsms/node-imagemagick) and thus require

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -70,11 +70,16 @@ optUtils.phantomPage.forEach(function(key) {
 });
 
 // The function that actually performs the screen rendering
-var _takeScreenshot = function(status) {
+var _takeScreenshot = function(status, optionsOverride) {
   if (status === 'fail') {
     page.close();
     phantom.exit(1);
     return;
+  }
+
+  if (typeof optionsOverride == 'object') {
+    var assign = require('object.assign').getPolyfill();
+    assign(options, optionsOverride);
   }
 
   // Wait `options.renderDelay` seconds for the page's JS to kick in
@@ -135,6 +140,9 @@ if (options.onCallback && options.takeShotOnCallback) {
 
     if (data == 'takeShot') {
       _takeScreenshot();
+    }
+    else if (data.event == 'takeShot') {
+      _takeScreenshot(null, data.options);
     }
   };
 } else if (options.onLoadFinished && !options.takeShotOnCallback) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     {
       "name": "Matthew Chase Whittemore",
       "email": "mcwhittemore@gmail.com"
+    },
+    {
+      "name": "Sergey Fayngold",
+      "email": "sergey@faynhost.com"
     }
   ],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "node >=0.7.00"
   ],
   "dependencies": {
-    "graceful-fs": "~3.0.4",
     "cross-spawn": "^0.2.3",
+    "graceful-fs": "~3.0.4",
+    "object.assign": "^4.0.3",
     "tmp": "~0.0.25"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Sometimes it is useful to override some of the options per page basis.

This pull request makes it possible by allowing to override them when calling it as follows:

```javascript
window.callPhantom({
    event: 'takeShot',
    options: {
        shotSize: {
            width: document.getElementsByTagName('html')[0].offsetWidth,
            height: document.getElementsByTagName('html')[0].offsetHeight
        }
    }
});
```