### PR TITLE
Account for zoomFactor when clipping to selector

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -25,10 +25,11 @@ exports.phantom = {
 , errorIfJSException: false
 , cookies: []
 , captureSelector: false
+, zoomFactor: 1
 };
 
 // Options that are just passed to the phantom page object
-exports.phantomPage = ['paperSize', 'zoomFactor', 'customHeaders', 'settings'];
+exports.phantomPage = ['paperSize', 'customHeaders', 'settings'];
 
 // Options that are callbacks for various phantom events
 exports.phantomCallback = ['onAlert', 'onCallback', 'onClosing', 'onConfirm',

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -94,21 +94,21 @@ var _takeScreenshot = function(status) {
     if (options.captureSelector) {
 
       // Handle captureSelector option
-      page.clipRect = page.evaluate(function(selector) {
+      page.clipRect = page.evaluate(function(selector, zoomFactor) {
         try {
           var selectorClipRect =
             document.querySelector(selector).getBoundingClientRect();
 
           return {
-              top: selectorClipRect.top
-            , left: selectorClipRect.left
-            , width: selectorClipRect.width
-            , height: selectorClipRect.height
+              top: selectorClipRect.top * zoomFactor
+            , left: selectorClipRect.left * zoomFactor
+            , width: selectorClipRect.width * zoomFactor
+            , height: selectorClipRect.height * zoomFactor
           };
         } catch (e) {
           throw new Error("Unable to fetch bounds for element " + selector);
         }
-      }, options.captureSelector);
+      }, options.captureSelector, options.zoomFactor);
     } else {
 
       //Set the rectangle of the page to render

--- a/test/tests.js
+++ b/test/tests.js
@@ -523,6 +523,28 @@ describe('Handling miscellaneous options', function() {
       });
     });
   });
+
+  it('creates a properly-sized page for zoomed shots of with selector', function(done) {
+    this.timeout(20000);
+
+    var fixture = fixtures[2];
+    var options = {
+      captureSelector: '#foo',
+      zoomFactor: 2
+    };
+
+    webshot(fixture.path, testPNG, options, function(err) {
+      if (err) return done(err);
+
+      im.identify(testPNG, function(err, features) {
+        if (err) return done(err);
+
+        features.width.should.equal(fixture.width * 2);
+        features.height.should.equal(fixture.height * 2);
+        done();
+      });
+    })
+  });
 });
 
 afterEach(function(done) {


### PR DESCRIPTION
`clipRect` values need to be multiplied by `zoomFactor` when using the `captureSelector` option, otherwise the image is cropped using the _un-zoomed_ dimensions.