### PR TITLE
Upgrade to phantomjs 2.1 (adds WOFF webfont support)

### DIFF
--- a/demo/webfonts.js
+++ b/demo/webfonts.js
@@ -1,0 +1,6 @@
+var webshot = require('../lib/webshot');
+
+webshot('https://www.google.com/fonts/specimen/Open+Sans', './webfonts.png', function(err) {
+  if (err) return console.log(err);
+  console.log('OK');
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "tmp": "~0.0.25"
   },
   "optionalDependencies": {
-    "phantomjs": "~1.9.7-1"
+    "phantomjs": "^2.1.2"
   },
   "devDependencies": {
     "imagemagick": "git://github.com/rsms/node-imagemagick.git",


### PR DESCRIPTION
Now that v2.1 has been officially released, phantomjs now fully supports webfonts. I've made a PR that updates the phantomjs dependency, and added a small webfonts example to the 'demo' directory.

Let me know if there's anything I can do to help get this merged!