### PR TITLE
Fixing phantomjs-prebuilt path detection

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -63,7 +63,7 @@ module.exports = function() {
 
   // Apply the compiled phantomjs path only if it compiled successfully
   try {
-    defaults.phantomPath = require('phantomjs').path;
+    defaults.phantomPath = require('phantomjs-prebuilt').path;
   } catch (ex) {}
 
   options = processOptions(options, defaults);


### PR DESCRIPTION
This fixes the autodetection of the phantomjs path since the dependency was changed to `phantomjs-prebuilt` in 58390b4