### PR TITLE
bumps graceful-fs to avoid node>= v6 breakage

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "node >=0.7.00"
   ],
   "dependencies": {
-    "graceful-fs": "~3.0.4",
     "cross-spawn": "^0.2.3",
+    "graceful-fs": "^4.1.3",
     "tmp": "~0.0.25"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Using node-webshot as a dependency, i get the following deprecation warning:

> npm WARN deprecated graceful-fs@3.0.8: graceful-fs v3.0.0 and before will fail on node releases >= v6.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.

running `npm ls graceful-fs`, i found that node-webshot uses the deprecated graceful-fs version

```
└─┬ webshot@0.18.0
  └── graceful-fs@3.0.8 
```

To fix the deprecation warning, i installed the current graceful-fs version
