### PR TITLE
set viewportsize equal to scrollHeight

### DIFF
--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -79,7 +79,7 @@ var _takeScreenshot = function(status) {
     return;
   }
 
-  //Work around for lazy loading web pages
+  //Work around for parallax scrolling effects
   var pageHeight = page.evaluate(function() {
     return document.body.scrollHeight;
   });

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -79,6 +79,16 @@ var _takeScreenshot = function(status) {
     return;
   }
 
+  //Work around for lazy loading web pages
+  var pageHeight = page.evaluate(function() {
+    return document.body.scrollHeight;
+  });
+
+  page.viewportSize = {
+    width: page.viewportSize.width,
+    height: pageHeight
+  }
+
   // Wait `options.renderDelay` seconds for the page's JS to kick in
   window.setTimeout(function () {
 


### PR DESCRIPTION
For some parallax website like https://sitegranny.com/ where content becomes visible once user scrolls down. Screenshot contains empty screen for section which is not visible to in browser. This pull request may solve this problem by changing the page view size before rendering.
