### PR TITLE
Pass zoomFactor option to phantom

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -29,7 +29,7 @@ exports.phantom = {
 };
 
 // Options that are just passed to the phantom page object
-exports.phantomPage = ['paperSize', 'customHeaders', 'settings'];
+exports.phantomPage = ['paperSize', 'customHeaders', 'settings', 'zoomFactor'];
 
 // Options that are callbacks for various phantom events
 exports.phantomCallback = ['onAlert', 'onCallback', 'onClosing', 'onConfirm',


### PR DESCRIPTION
Somewhere down the line the library stopped passing `zoomFactor` to phantom, and this was messing up my zommed screenshot.

This is an attempt to fix it.