### PR TITLE
Kill zombie phantom processes after JS error

### DIFF
--- a/lib/webshot.js
+++ b/lib/webshot.js
@@ -234,6 +234,10 @@ function spawnPhantom(site, path, streaming, options, cb) {
     phantomProc.stderr.on('data', function(data) {
       if (options.errorIfJSException) {
         calledCallback = true;
+
+        // Send the kill signal
+        phantomProc.kill('SIGKILL');
+
         clearTimeout(timeoutID);
         cb(new Error('' + data))
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "node >=0.7.00"
   ],
   "dependencies": {
-    "graceful-fs": "~3.0.4",
     "cross-spawn": "^0.2.3",
+    "graceful-fs": "^4.1.3",
     "tmp": "~0.0.25"
   },
   "optionalDependencies": {


### PR DESCRIPTION
When `options.errorIfJSException === true`, the phantom process is never killed if there is actually a JS exception.