### PR TITLE
Added support for pageSize.header.contents and pageSize.footer.contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,21 +216,13 @@ object](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage):
 `paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`.
 
 To set a header and footer set `contentsTemplateString` or `contentsTemplateFile`
-in `paperSize.header` or `paperSize.footer`, where `{contentsTemplateFile}` is an
+in `paperSize.header` or `paperSize.footer`, where `contentsTemplateFile` is an
 absolute path to a file containing the header or footer template.
 
 You may use `{pageNumber}` and `{numberOfPages}` placeholders in the header and
 footer templates, plus you may also specify other placeholders specifying
-`paperSize.header.placeholders` as an object.
-
-When using
-`paperSize.header.contents` or `paperSize.footer.contents`, pass a string to use
-as the header or footer and use the placeholders `{pageNumber}` and `{numberOfPages}`
-where needed. You cannot pass a `phantom.callback` to `paperSize.header.contents`
-or `paperSize.footer.contents`.
-
-You can also pass `paperSize.header.placeholders` as an object with each property
-being a placeholder you'd like to use in the header or footer template.
+`paperSize.header.placeholders` as an object. If you set a placeholder `foo` to
+the value `bar` you can use it in your header or footer as `{foo}`.
 
 ### Phantom callbacks
 Arbitrary scripts can be run on the page before it gets rendered by using any of

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ By default this package installs PhantomJS 1.9.x. Several issues exist in this v
 In addition to these options, the following options can be specified and will be
 passed to the [Phantom page
 object](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage):
-`paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`. When using
+`paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`.
+
+When using
 `paperSize.header.contents` or `paperSize.footer.contents`, pass a string to use
 as the header or footer and use the placeholders `{pageNumber}` and `{numberOfPages}`
 where needed. You cannot pass a `phantom.callback` to `paperSize.header.contents`

--- a/README.md
+++ b/README.md
@@ -213,7 +213,11 @@ By default this package installs PhantomJS 1.9.x. Several issues exist in this v
 In addition to these options, the following options can be specified and will be
 passed to the [Phantom page
 object](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage):
-`paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`.
+`paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`. When using
+`paperSize.header.contents` or `paperSize.footer.contents`, pass a string to use
+as the header or footer and use the placeholders `{pageNumber}` and `{numberOfPages}`
+where needed. You cannot pass a `phantom.callback` to `paperSize.header.contents`
+or `paperSize.footer.contents`.
 
 ### Phantom callbacks
 Arbitrary scripts can be run on the page before it gets rendered by using any of
@@ -229,13 +233,13 @@ var options = {
     for (var i=0; i<links.length; i++) {
       var link = links[i];
       link.innerHTML = 'My custom text';
-    } 
+    }
   }
 };
 ```
 
 Note that the script will be serialized and then passed to Phantom as text, so all
-variable scope information will be lost. However, variables from the caller can be 
+variable scope information will be lost. However, variables from the caller can be
 passed into the script as follows:
 
 ```javascript
@@ -247,7 +251,7 @@ var options = {
       for (var i=0; i<links.length; i++) {
         var link = links[i];
         link.innerHTML = this.foo;
-      } 
+      }
     }
   , context: {foo: 'My custom text'}
   }

--- a/README.md
+++ b/README.md
@@ -215,11 +215,22 @@ passed to the [Phantom page
 object](https://github.com/ariya/phantomjs/wiki/API-Reference-WebPage):
 `paperSize`, `zoomFactor`, `cookies`, `customHeaders`, and `settings`.
 
+To set a header and footer set `contentsTemplateString` or `contentsTemplateFile`
+in `paperSize.header` or `paperSize.footer`, where `{contentsTemplateFile}` is an
+absolute path to a file containing the header or footer template.
+
+You may use `{pageNumber}` and `{numberOfPages}` placeholders in the header and
+footer templates, plus you may also specify other placeholders specifying
+`paperSize.header.placeholders` as an object.
+
 When using
 `paperSize.header.contents` or `paperSize.footer.contents`, pass a string to use
 as the header or footer and use the placeholders `{pageNumber}` and `{numberOfPages}`
 where needed. You cannot pass a `phantom.callback` to `paperSize.header.contents`
 or `paperSize.footer.contents`.
+
+You can also pass `paperSize.header.placeholders` as an object with each property
+being a placeholder you'd like to use in the header or footer template.
 
 ### Phantom callbacks
 Arbitrary scripts can be run on the page before it gets rendered by using any of

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -95,9 +95,9 @@ optUtils.phantomPage.forEach(function(key) {
         var contents = paperSize.footer.contentsTemplateString;
         contents = contents.replace("{pageNumber}", pageNumber);
         contents = contents.replace("{numberOfPages}", numberOfPages);
-        if (paperSize.header.placeholders) {
-          Object.keys(paperSize.header.placeholders).forEach(function(key) {
-            contents = contents.replace("{" + key + "}", paperSize.header.placeholders[key]);
+        if (paperSize.footer.placeholders) {
+          Object.keys(paperSize.footer.placeholders).forEach(function(key) {
+            contents = contents.replace("{" + key + "}", paperSize.footer.placeholders[key]);
           });
         }
         return contents;

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -69,6 +69,24 @@ var toOverwrite = optUtils.mergeObjects(
 
 optUtils.phantomPage.forEach(function(key) {
   if (toOverwrite[key]) page[key] = toOverwrite[key];
+  if (key === "paperSize") {
+    var paperSize = page[key];
+    if (paperSize.header && paperSize.header.contents) {
+      paperSize.header.contentsTemplate = paperSize.header.contents;
+      paperSize.header.contents = phantom.callback(function(pageNumber, numberOfPages) {
+        var contents = paperSize.header.contentsTemplate.replace("{pageNumber}", pageNumber).replace("{numberOfPages}", numberOfPages);
+        return contents;
+      });
+    }
+    if (paperSize.footer && paperSize.footer.contents) {
+      paperSize.footer.contentsTemplate = paperSize.footer.contents;
+      paperSize.footer.contents = phantom.callback(function(pageNumber, numberOfPages) {
+        var contents = paperSize.footer.contentsTemplate.replace("{pageNumber}", pageNumber).replace("{numberOfPages}", numberOfPages);
+        return contents;
+      });
+    }
+    page[key] = paperSize;
+  }
 });
 
 // The function that actually performs the screen rendering

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -74,6 +74,9 @@ optUtils.phantomPage.forEach(function(key) {
     if (paperSize.header && paperSize.header.contentsTemplateFile) {
       paperSize.header.contentsTemplateString = fs.read(paperSize.header.contentsTemplateFile);
     }
+    if (paperSize.header && paperSize.header.contentsTemplateStyle) {
+      paperSize.header.contentsTemplateString += "<style>" + fs.read(paperSize.header.contentsTemplateStyle) + "</style>";
+    }
     if (paperSize.header && paperSize.header.contentsTemplateString) {
       paperSize.header.contents = phantom.callback(function(pageNumber, numberOfPages) {
         var contents = paperSize.header.contentsTemplateString;
@@ -89,6 +92,9 @@ optUtils.phantomPage.forEach(function(key) {
     }
     if (paperSize.footer && paperSize.footer.contentsTemplateFile) {
       paperSize.footer.contentsTemplateString = fs.read(paperSize.footer.contentsTemplateFile);
+    }
+    if (paperSize.footer && paperSize.footer.contentsTemplateStyle) {
+      paperSize.footer.contentsTemplateString += "<style>" + fs.read(paperSize.footer.contentsTemplateStyle) + "</style>";
     }
     if (paperSize.footer && paperSize.footer.contentsTemplateString) {
       paperSize.footer.contents = phantom.callback(function(pageNumber, numberOfPages) {

--- a/lib/webshot.phantom.js
+++ b/lib/webshot.phantom.js
@@ -71,17 +71,35 @@ optUtils.phantomPage.forEach(function(key) {
   if (toOverwrite[key]) page[key] = toOverwrite[key];
   if (key === "paperSize") {
     var paperSize = page[key];
-    if (paperSize.header && paperSize.header.contents) {
-      paperSize.header.contentsTemplate = paperSize.header.contents;
+    if (paperSize.header && paperSize.header.contentsTemplateFile) {
+      paperSize.header.contentsTemplateString = fs.read(paperSize.header.contentsTemplateFile);
+    }
+    if (paperSize.header && paperSize.header.contentsTemplateString) {
       paperSize.header.contents = phantom.callback(function(pageNumber, numberOfPages) {
-        var contents = paperSize.header.contentsTemplate.replace("{pageNumber}", pageNumber).replace("{numberOfPages}", numberOfPages);
+        var contents = paperSize.header.contentsTemplateString;
+        contents = contents.replace("{pageNumber}", pageNumber);
+        contents = contents.replace("{numberOfPages}", numberOfPages);
+        if (paperSize.header.placeholders) {
+          Object.keys(paperSize.header.placeholders).forEach(function(key) {
+            contents = contents.replace("{" + key + "}", paperSize.header.placeholders[key]);
+          });
+        }
         return contents;
       });
     }
-    if (paperSize.footer && paperSize.footer.contents) {
-      paperSize.footer.contentsTemplate = paperSize.footer.contents;
+    if (paperSize.footer && paperSize.footer.contentsTemplateFile) {
+      paperSize.footer.contentsTemplateString = fs.read(paperSize.footer.contentsTemplateFile);
+    }
+    if (paperSize.footer && paperSize.footer.contentsTemplateString) {
       paperSize.footer.contents = phantom.callback(function(pageNumber, numberOfPages) {
-        var contents = paperSize.footer.contentsTemplate.replace("{pageNumber}", pageNumber).replace("{numberOfPages}", numberOfPages);
+        var contents = paperSize.footer.contentsTemplateString;
+        contents = contents.replace("{pageNumber}", pageNumber);
+        contents = contents.replace("{numberOfPages}", numberOfPages);
+        if (paperSize.header.placeholders) {
+          Object.keys(paperSize.header.placeholders).forEach(function(key) {
+            contents = contents.replace("{" + key + "}", paperSize.header.placeholders[key]);
+          });
+        }
         return contents;
       });
     }


### PR DESCRIPTION
Because you can't pass a phantom.callback to pageSize.header.contents or pageSize.footer.contents I've added functionality to instead use a string passed to these properties as a template build them into a phantom.callback on the other side.

Two placeholders {pageNumber} and {numberOfPages} are available and replaced on the fly, these come from the phantom callback context.

For example:

```
header: {
  height: "3cm",
  contents: "<span style=\"font-family: sans-serif;\">Header - {pageNumber}/{numberOfPages}<span>"
},
footer: {
  height: "1cm",
  contents: "<span>Footer - {pageNumber}/{numberOfPages}<span>"
}
```

I've also adjusted the doc to cover this.